### PR TITLE
Limit photo uploads and gate product creation

### DIFF
--- a/add.html
+++ b/add.html
@@ -52,6 +52,7 @@
               Add photos
             </button>
 </div>
+<div class="mt-4" id="photoPreview" role="list"></div>
 </section>
 <div class="fixed bottom-20 w-full px-4 py-3">
 <button class="w-full bg-primary text-white font-bold py-3 px-5 rounded-lg text-base disabled:opacity-50 disabled:cursor-not-allowed" id="createProductButton" type="button">
@@ -79,29 +80,102 @@
 <script>
     const addPhotosButton = document.getElementById("addPhotosButton");
     const productPhotosInput = document.getElementById("productPhotos");
+    const photoPreview = document.getElementById("photoPreview");
     const createProductButton = document.getElementById("createProductButton");
+    const MAX_PHOTOS = 5;
+    let selectedFiles = [];
 
     const updateCreateButtonState = () => {
       createProductButton.disabled = productPhotosInput.files.length === 0;
+    };
+
+    const syncInputFiles = () => {
+      const dataTransfer = new DataTransfer();
+      selectedFiles.forEach((file) => dataTransfer.items.add(file));
+      productPhotosInput.files = dataTransfer.files;
+      updateCreateButtonState();
+    };
+
+    const renderPreview = () => {
+      photoPreview.innerHTML = "";
+
+      if (selectedFiles.length === 0) {
+        photoPreview.className = "mt-4";
+        return;
+      }
+
+      photoPreview.className = "mt-4 grid grid-cols-3 gap-3";
+
+      selectedFiles.forEach((file, index) => {
+        const previewItem = document.createElement("div");
+        previewItem.className = "relative w-24 h-24 rounded-lg overflow-hidden border border-black/10 dark:border-white/10";
+        previewItem.setAttribute("role", "listitem");
+
+        const removeButton = document.createElement("button");
+        removeButton.type = "button";
+        removeButton.className = "absolute -top-2 -right-2 bg-black/70 text-white rounded-full w-6 h-6 flex items-center justify-center text-xs";
+        removeButton.setAttribute("aria-label", `Remove ${file.name}`);
+        removeButton.textContent = "✕";
+        removeButton.addEventListener("click", () => {
+          selectedFiles = selectedFiles.filter((_, fileIndex) => fileIndex !== index);
+          syncInputFiles();
+          renderPreview();
+        });
+
+        const image = document.createElement("img");
+        image.alt = file.name;
+        image.className = "w-full h-full object-cover";
+
+        const reader = new FileReader();
+        reader.onload = (event) => {
+          image.src = event.target.result;
+        };
+        reader.readAsDataURL(file);
+
+        previewItem.appendChild(image);
+        previewItem.appendChild(removeButton);
+        photoPreview.appendChild(previewItem);
+      });
     };
 
     addPhotosButton.addEventListener("click", () => {
       productPhotosInput.click();
     });
 
-    productPhotosInput.addEventListener("change", () => {
-      const files = Array.from(productPhotosInput.files);
+    productPhotosInput.addEventListener("change", (event) => {
+      const incomingFiles = Array.from(event.target.files);
+      productPhotosInput.value = "";
+      let limitExceeded = false;
 
-      if (files.length > 5) {
-        const dataTransfer = new DataTransfer();
-        files.slice(0, 5).forEach((file) => dataTransfer.items.add(file));
-        productPhotosInput.files = dataTransfer.files;
-        alert("You can only select up to 5 photos.");
+      incomingFiles.forEach((file) => {
+        const isDuplicate = selectedFiles.some(
+          (existingFile) =>
+            existingFile.name === file.name &&
+            existingFile.size === file.size &&
+            existingFile.lastModified === file.lastModified
+        );
+
+        if (isDuplicate) {
+          return;
+        }
+
+        if (selectedFiles.length >= MAX_PHOTOS) {
+          limitExceeded = true;
+          return;
+        }
+
+        selectedFiles.push(file);
+      });
+
+      if (limitExceeded) {
+        alert(`You can only select up to ${MAX_PHOTOS} photos.`);
       }
 
-      updateCreateButtonState();
+      syncInputFiles();
+      renderPreview();
     });
 
-    updateCreateButtonState();
+    syncInputFiles();
+    renderPreview();
   </script>
 </body></html>

--- a/add.html
+++ b/add.html
@@ -104,16 +104,16 @@
         return;
       }
 
-      photoPreview.className = "mt-4 grid grid-cols-3 gap-3";
+      photoPreview.className = "mt-4 space-y-3";
 
       selectedFiles.forEach((file, index) => {
         const previewItem = document.createElement("div");
-        previewItem.className = "relative w-24 h-24 rounded-lg overflow-hidden border border-black/10 dark:border-white/10";
+        previewItem.className = "relative w-full rounded-lg overflow-hidden border border-black/10 dark:border-white/10";
         previewItem.setAttribute("role", "listitem");
 
         const removeButton = document.createElement("button");
         removeButton.type = "button";
-        removeButton.className = "absolute -top-2 -right-2 bg-black/70 text-white rounded-full w-6 h-6 flex items-center justify-center text-xs";
+        removeButton.className = "absolute top-3 right-3 bg-black/70 text-white rounded-full w-7 h-7 flex items-center justify-center text-sm";
         removeButton.setAttribute("aria-label", `Remove ${file.name}`);
         removeButton.textContent = "✕";
         removeButton.addEventListener("click", () => {
@@ -124,7 +124,7 @@
 
         const image = document.createElement("img");
         image.alt = file.name;
-        image.className = "w-full h-full object-cover";
+        image.className = "w-full h-auto object-cover";
 
         const reader = new FileReader();
         reader.onload = (event) => {

--- a/add.html
+++ b/add.html
@@ -47,13 +47,14 @@
 <p class="font-bold text-lg text-black dark:text-white">Add photos</p>
 <p class="text-sm text-black/60 dark:text-white/60">Add up to 5 photos of your product</p>
 </div>
-<button class="bg-primary/20 dark:bg-primary/30 text-primary font-bold py-2 px-4 rounded-full text-sm">
+<input accept="image/*" class="hidden" id="productPhotos" multiple type="file"/>
+<button class="bg-primary/20 dark:bg-primary/30 text-primary font-bold py-2 px-4 rounded-full text-sm" id="addPhotosButton" type="button">
               Add photos
             </button>
 </div>
 </section>
 <div class="fixed bottom-20 w-full px-4 py-3">
-<button class="w-full bg-primary text-white font-bold py-3 px-5 rounded-lg text-base">
+<button class="w-full bg-primary text-white font-bold py-3 px-5 rounded-lg text-base disabled:opacity-50 disabled:cursor-not-allowed" id="createProductButton" type="button">
             Create Product
           </button>
 </div>
@@ -75,5 +76,32 @@
 </nav>
 </footer>
 </div>
+<script>
+    const addPhotosButton = document.getElementById("addPhotosButton");
+    const productPhotosInput = document.getElementById("productPhotos");
+    const createProductButton = document.getElementById("createProductButton");
 
+    const updateCreateButtonState = () => {
+      createProductButton.disabled = productPhotosInput.files.length === 0;
+    };
+
+    addPhotosButton.addEventListener("click", () => {
+      productPhotosInput.click();
+    });
+
+    productPhotosInput.addEventListener("change", () => {
+      const files = Array.from(productPhotosInput.files);
+
+      if (files.length > 5) {
+        const dataTransfer = new DataTransfer();
+        files.slice(0, 5).forEach((file) => dataTransfer.items.add(file));
+        productPhotosInput.files = dataTransfer.files;
+        alert("You can only select up to 5 photos.");
+      }
+
+      updateCreateButtonState();
+    });
+
+    updateCreateButtonState();
+  </script>
 </body></html>


### PR DESCRIPTION
## Summary
- add a hidden file input triggered by the Add photos button and cap the selection at five images
- disable the Create Product button until at least one photo has been chosen

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e38dec9b088325bf0dfb21c876d750