### PR TITLE
Replace manage page back arrow with close button

### DIFF
--- a/manage.html
+++ b/manage.html
@@ -6,6 +6,7 @@
 <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
 <link crossorigin="" href="https://fonts.gstatic.com/" rel="preconnect"/>
 <link as="style" href="https://fonts.googleapis.com/css2?display=swap&amp;family=Manrope%3Awght%40400%3B500%3B700%3B800&amp;family=Noto+Sans%3Awght%40400%3B500%3B700%3B900" onload="this.rel='stylesheet'" rel="stylesheet"/>
+<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet"/>
 <script id="tailwind-config">
     tailwind.config = {
       darkMode: "class",
@@ -58,15 +59,13 @@
 <div class="flex flex-col min-h-screen">
 <header class="sticky top-0 z-10 bg-background-light dark:bg-background-dark bg-opacity-80 dark:bg-opacity-80 backdrop-blur-sm">
 <div class="container mx-auto px-4">
-<div class="flex items-center justify-between py-4">
-<button class="text-black dark:text-white">
-<svg fill="currentColor" height="24" viewBox="0 0 256 256" width="24" xmlns="http://www.w3.org/2000/svg">
-<path d="M224,128a8,8,0,0,1-8,8H59.31l58.35,58.34a8,8,0,0,1-11.32,11.32l-72-72a8,8,0,0,1,0-11.32l72-72a8,8,0,0,1,11.32,11.32L59.31,120H216A8,8,0,0,1,224,128Z"></path>
-</svg>
-</button>
-<h1 class="text-lg font-bold text-black dark:text-white">Manage Product</h1>
-<div class="w-6"></div>
-</div>
+  <div class="flex items-center justify-between py-4">
+    <button class="p-2 text-primary" onclick="window.location.href='index.html';" type="button">
+      <span class="material-symbols-outlined"> close </span>
+    </button>
+    <h1 class="text-lg font-bold text-black dark:text-white">Manage Product</h1>
+    <div class="w-6"></div>
+  </div>
 </div>
 </header>
 <main class="flex-grow">


### PR DESCRIPTION
## Summary
- add Material Symbols font to manage page
- swap the back arrow for a close icon that redirects to the home page

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e398e90b648325a4769af032c7dfcb