### PR TITLE
Embed Manage button within product card layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -127,7 +127,7 @@
 
     if (isProcessed) {
       const button = document.createElement("button");
-      button.className = "ml-auto bg-primary/20 dark:bg-primary/30 text-primary font-bold py-2 px-4 rounded text-sm";
+      button.className = "bg-primary/20 dark:bg-primary/30 text-primary font-bold py-2 px-4 rounded text-sm";
       button.textContent = "Manage";
       button.addEventListener("click", () => {
         const productId = product?.Id ?? "";
@@ -138,7 +138,11 @@
         window.location.href = `manage.html?productId=${encodeURIComponent(productId)}`;
       });
 
-      body.appendChild(button);
+      const actions = document.createElement("div");
+      actions.className = "mt-2 flex justify-end";
+      actions.appendChild(button);
+
+      content.appendChild(actions);
     }
 
     card.appendChild(body);


### PR DESCRIPTION
## Summary
- move the Manage button rendering into the card content so it displays as part of the product card
- add an action row that right-aligns the Manage button beneath the product details

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e39bac62d48325b051bdf8dd36ef9f