### PR TITLE
Upload product images via API before redirect

### DIFF
--- a/add.html
+++ b/add.html
@@ -160,6 +160,49 @@
       renderPreview();
     });
 
+    const setCreateButtonState = (isSubmitting) => {
+      if (isSubmitting) {
+        createProductButton.disabled = true;
+        createProductButton.dataset.originalText = createProductButton.textContent;
+        createProductButton.textContent = "Uploading...";
+      } else {
+        createProductButton.disabled = selectedFiles.length === 0;
+        if (createProductButton.dataset.originalText) {
+          createProductButton.textContent = createProductButton.dataset.originalText;
+          delete createProductButton.dataset.originalText;
+        }
+      }
+    };
+
+    createProductButton.addEventListener("click", async () => {
+      if (selectedFiles.length === 0) {
+        return;
+      }
+
+      const formData = new FormData();
+      selectedFiles.forEach((file, index) => {
+        formData.append(`file${index + 1}`, file);
+      });
+
+      try {
+        setCreateButtonState(true);
+        const response = await fetch("https://localhost:7168/products/add", {
+          method: "POST",
+          body: formData,
+        });
+
+        if (!response.ok) {
+          throw new Error("Failed to upload product images.");
+        }
+
+        window.location.href = "index.html";
+      } catch (error) {
+        console.error(error);
+        alert("There was a problem uploading the product. Please try again.");
+        setCreateButtonState(false);
+      }
+    });
+
     syncInputFiles();
     renderPreview();
 


### PR DESCRIPTION
## Summary
- add a submission handler for the create product button that posts the selected files to the backend API
- show a loading state during the upload and redirect back to the index page after a successful response

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e39f34e1c48325b42c8622e3c71058