### PR TITLE
Align measurement fields styling with other inputs

### DIFF
--- a/manage.html
+++ b/manage.html
@@ -149,22 +149,34 @@
 <label class="text-sm font-medium text-black/60 dark:text-white/60">Measurements (cm)</label>
 <div class="grid grid-cols-3 gap-2 mt-1">
 <div>
-<input class="w-full h-12 px-3 bg-white/5 dark:bg-white/5 rounded-lg border border-black/10 dark:border-white/10 text-black dark:text-white placeholder-black/40 dark:placeholder-white/40" id="measurement-chest" placeholder="Chest" type="number"/>
+<div class="bg-white/5 dark:bg-white/5 rounded-lg border border-black/10 dark:border-white/10">
+<input class="w-full h-12 px-4 bg-transparent text-black dark:text-white placeholder-black/40 dark:placeholder-white/40" id="measurement-chest" placeholder="Chest" type="number"/>
+</div>
 </div>
 <div>
-<input class="w-full h-12 px-3 bg-white/5 dark:bg-white/5 rounded-lg border border-black/10 dark:border-white/10 text-black dark:text-white placeholder-black/40 dark:placeholder-white/40" id="measurement-waist" placeholder="Waist" type="number"/>
+<div class="bg-white/5 dark:bg-white/5 rounded-lg border border-black/10 dark:border-white/10">
+<input class="w-full h-12 px-4 bg-transparent text-black dark:text-white placeholder-black/40 dark:placeholder-white/40" id="measurement-waist" placeholder="Waist" type="number"/>
+</div>
 </div>
 <div>
-<input class="w-full h-12 px-3 bg-white/5 dark:bg-white/5 rounded-lg border border-black/10 dark:border-white/10 text-black dark:text-white placeholder-black/40 dark:placeholder-white/40" id="measurement-hip" placeholder="Hip" type="number"/>
+<div class="bg-white/5 dark:bg-white/5 rounded-lg border border-black/10 dark:border-white/10">
+<input class="w-full h-12 px-4 bg-transparent text-black dark:text-white placeholder-black/40 dark:placeholder-white/40" id="measurement-hip" placeholder="Hip" type="number"/>
+</div>
 </div>
 <div>
-<input class="w-full h-12 px-3 bg-white/5 dark:bg-white/5 rounded-lg border border-black/10 dark:border-white/10 text-black dark:text-white placeholder-black/40 dark:placeholder-white/40" id="measurement-length" placeholder="Length" type="number"/>
+<div class="bg-white/5 dark:bg-white/5 rounded-lg border border-black/10 dark:border-white/10">
+<input class="w-full h-12 px-4 bg-transparent text-black dark:text-white placeholder-black/40 dark:placeholder-white/40" id="measurement-length" placeholder="Length" type="number"/>
+</div>
 </div>
 <div>
-<input class="w-full h-12 px-3 bg-white/5 dark:bg-white/5 rounded-lg border border-black/10 dark:border-white/10 text-black dark:text-white placeholder-black/40 dark:placeholder-white/40" id="measurement-sleeve" placeholder="Sleeve" type="number"/>
+<div class="bg-white/5 dark:bg-white/5 rounded-lg border border-black/10 dark:border-white/10">
+<input class="w-full h-12 px-4 bg-transparent text-black dark:text-white placeholder-black/40 dark:placeholder-white/40" id="measurement-sleeve" placeholder="Sleeve" type="number"/>
+</div>
 </div>
 <div>
-<input class="w-full h-12 px-3 bg-white/5 dark:bg-white/5 rounded-lg border border-black/10 dark:border-white/10 text-black dark:text-white placeholder-black/40 dark:placeholder-white/40" id="measurement-shoulder" placeholder="Shoulder" type="number"/>
+<div class="bg-white/5 dark:bg-white/5 rounded-lg border border-black/10 dark:border-white/10">
+<input class="w-full h-12 px-4 bg-transparent text-black dark:text-white placeholder-black/40 dark:placeholder-white/40" id="measurement-shoulder" placeholder="Shoulder" type="number"/>
+</div>
 </div>
 </div>
 </div>


### PR DESCRIPTION
## Summary
- wrap the measurement inputs in the same styled container used by other fields
- update measurement inputs to use transparent backgrounds and consistent padding

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_e_68e3b94c5adc8325bbd865fd21000b95