### PR TITLE
Add Facebook draft publish action to manage page

### DIFF
--- a/manage.html
+++ b/manage.html
@@ -284,7 +284,22 @@
             if (typeof parsed === 'string') {
               publishUrl = parsed;
             } else if (parsed && typeof parsed === 'object') {
-              publishUrl = parsed.url ?? parsed.Url ?? '';
+              const draftLink = typeof parsed.draftLink === 'string' ? parsed.draftLink : '';
+              const fallbackUrl = parsed.url ?? parsed.Url ?? '';
+
+              if (draftLink) {
+                const match = draftLink.match(/https?:\/\/\S+/);
+
+                if (match && match[0]) {
+                  publishUrl = match[0];
+                } else {
+                  publishUrl = draftLink;
+                }
+              }
+
+              if (!publishUrl && typeof fallbackUrl === 'string' && fallbackUrl) {
+                publishUrl = fallbackUrl;
+              }
             }
           } catch (parseError) {
             publishUrl = rawResponse.trim();

--- a/manage.html
+++ b/manage.html
@@ -205,7 +205,7 @@
 <div class="w-full px-4">
 <div class="space-y-3">
 <button class="w-full h-12 bg-primary text-white font-bold rounded-lg text-base" id="save-changes">Save Changes</button>
-<button class="w-full h-12 bg-primary/20 dark:bg-primary/30 text-primary font-bold rounded-lg text-base">Create Facebook Post</button>
+<button class="w-full h-12 bg-primary/20 dark:bg-primary/30 text-primary font-bold rounded-lg text-base" id="create-facebook-post">Create Facebook Post</button>
 <button class="w-full h-12 bg-transparent text-red-500 font-bold rounded-lg text-base" id="delete-product">Delete Product</button>
 </div>
 </div>
@@ -220,6 +220,7 @@
     const productId = params.get('productId');
     const deleteButton = document.getElementById('delete-product');
     const saveButton = document.getElementById('save-changes');
+    const createPostButton = document.getElementById('create-facebook-post');
 
     if (deleteButton) {
       deleteButton.addEventListener('click', async () => {
@@ -256,6 +257,50 @@
     }
 
     fetchProduct(productId);
+
+    if (createPostButton) {
+      createPostButton.addEventListener('click', async () => {
+        try {
+          const response = await fetch(
+            `https://localhost:7168/products/${encodeURIComponent(productId)}/publish-fb-draft`,
+            {
+              method: 'POST',
+              headers: {
+                Accept: 'application/json',
+              },
+            },
+          );
+
+          if (!response.ok) {
+            throw new Error(`Failed to create Facebook post draft. Status: ${response.status}`);
+          }
+
+          const rawResponse = await response.text();
+          let publishUrl = '';
+
+          try {
+            const parsed = JSON.parse(rawResponse);
+
+            if (typeof parsed === 'string') {
+              publishUrl = parsed;
+            } else if (parsed && typeof parsed === 'object') {
+              publishUrl = parsed.url ?? parsed.Url ?? '';
+            }
+          } catch (parseError) {
+            publishUrl = rawResponse.trim();
+          }
+
+          if (!publishUrl) {
+            throw new Error('The publish URL was not provided in the response.');
+          }
+
+          window.open(publishUrl, '_blank', 'noopener,noreferrer');
+        } catch (error) {
+          console.error('Unable to create Facebook post.', error);
+          window.alert('Unable to create the Facebook post. Please try again.');
+        }
+      });
+    }
 
     if (saveButton) {
       saveButton.addEventListener('click', async () => {


### PR DESCRIPTION
## Summary
- add an id to the create facebook post button for scripting
- call the publish facebook draft endpoint and open the returned URL in a new tab

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4e8a29c148325a0973969680d30d0