### PR TITLE
Add footer action bar to manage page

### DIFF
--- a/manage.html
+++ b/manage.html
@@ -212,14 +212,30 @@
 </div>
 </div>
 </main>
-<footer class="sticky bottom-0 bg-background-light dark:bg-background-dark bg-opacity-80 dark:bg-opacity-80 backdrop-blur-sm py-4">
-<div class="w-full px-4">
-<div class="space-y-3">
-<button class="w-full h-12 bg-primary text-white font-bold rounded-lg text-base" id="save-changes">Save Changes</button>
-<button class="w-full h-12 bg-primary/20 dark:bg-primary/30 text-primary font-bold rounded-lg text-base" id="create-facebook-post">Create Facebook Post</button>
-<button class="w-full h-12 bg-transparent text-red-500 font-bold rounded-lg text-base" id="delete-product">Delete Product</button>
-</div>
-</div>
+<footer class="sticky bottom-0 bg-background-light dark:bg-background-dark/80 backdrop-blur-sm border-t border-black/10 dark:border-white/10">
+  <nav class="flex justify-around items-center h-20 px-2">
+    <button class="flex flex-col items-center gap-1 text-gray-500 dark:text-gray-400 hover:text-primary dark:hover:text-primary transition-colors" id="save-product" type="button">
+      <span class="material-symbols-outlined text-2xl leading-none">save</span>
+      <span class="text-xs font-medium">Save product</span>
+    </button>
+    <button class="flex flex-col items-center gap-1 text-gray-500 dark:text-gray-400 hover:text-primary dark:hover:text-primary transition-colors" id="refresh-product" type="button">
+      <span class="material-symbols-outlined text-2xl leading-none">refresh</span>
+      <span class="text-xs font-medium">Refresh product</span>
+    </button>
+    <button class="flex flex-col items-center gap-1 text-gray-500 dark:text-gray-400 hover:text-primary dark:hover:text-primary transition-colors" id="extract-job" type="button">
+      <span class="material-symbols-outlined text-2xl leading-none">precision_manufacturing</span>
+      <span class="text-xs font-medium">Extract Job</span>
+    </button>
+    <button class="flex flex-col items-center gap-1 text-gray-500 dark:text-gray-400 hover:text-primary dark:hover:text-primary transition-colors" id="facebook-job" type="button">
+      <span class="material-symbols-outlined text-2xl leading-none">share</span>
+      <span class="text-xs font-medium">Facebook Job</span>
+    </button>
+    <button class="flex flex-col items-center gap-1 text-red-500 dark:text-red-400 hover:text-red-600 dark:hover:text-red-300 transition-colors" id="delete-product" type="button">
+      <span class="material-symbols-outlined text-2xl leading-none">delete</span>
+      <span class="text-xs font-medium">Delete</span>
+    </button>
+  </nav>
+  <div class="pb-safe"></div>
 </footer>
 </div>
 
@@ -230,15 +246,18 @@
     const params = new URLSearchParams(window.location.search);
     const productId = params.get('productId');
     const deleteButton = document.getElementById('delete-product');
-    const saveButton = document.getElementById('save-changes');
-    const createPostButton = document.getElementById('create-facebook-post');
+    const saveButton = document.getElementById('save-product');
+    const facebookJobButton = document.getElementById('facebook-job');
+    const refreshButton = document.getElementById('refresh-product');
+    const extractJobButton = document.getElementById('extract-job');
+
+    if (!productId) {
+      console.warn('No productId provided in the query string.');
+      return;
+    }
 
     if (deleteButton) {
       deleteButton.addEventListener('click', async () => {
-        if (!productId) {
-          return;
-        }
-
         const confirmed = window.confirm('Are you sure you want to delete this product?');
 
         if (!confirmed) {
@@ -262,15 +281,39 @@
       });
     }
 
-    if (!productId) {
-      console.warn('No productId provided in the query string.');
-      return;
+    if (refreshButton) {
+      refreshButton.addEventListener('click', () => {
+        fetchProduct(productId);
+      });
+    }
+
+    if (extractJobButton) {
+      extractJobButton.addEventListener('click', async () => {
+        try {
+          const response = await fetch(`https://localhost:7168/products/${encodeURIComponent(productId)}/extract-job`, {
+            method: 'POST',
+            headers: {
+              Accept: 'application/json',
+            },
+          });
+
+          if (!response.ok) {
+            throw new Error(`Failed to start extract job. Status: ${response.status}`);
+          }
+
+          window.alert('Extract job started successfully.');
+          await fetchProduct(productId);
+        } catch (error) {
+          console.error('Unable to start extract job.', error);
+          window.alert('Unable to start the extract job. Please try again.');
+        }
+      });
     }
 
     fetchProduct(productId);
 
-    if (createPostButton) {
-      createPostButton.addEventListener('click', async () => {
+    if (facebookJobButton) {
+      facebookJobButton.addEventListener('click', async () => {
         try {
           const response = await fetch(
             `https://localhost:7168/products/${encodeURIComponent(productId)}/publish-fb-draft`,
@@ -443,6 +486,8 @@
       }
     }
 
+    let sliderInitialized = false;
+
     function populateImages(images) {
       if (!slider || !indicators) {
         return;
@@ -472,7 +517,10 @@
 
       slider.scrollTo({ left: 0 });
       updateIndicators();
-      slider.addEventListener('scroll', handleSliderScroll, { passive: true });
+      if (!sliderInitialized) {
+        slider.addEventListener('scroll', handleSliderScroll, { passive: true });
+        sliderInitialized = true;
+      }
     }
 
     let scrollTicking = false;


### PR DESCRIPTION
## Summary
- replace the stacked action buttons with a sticky footer action bar similar to the index page
- wire up new footer actions for saving, refreshing, triggering extract/Facebook jobs, and deleting a product
- ensure the image slider only binds its scroll listener once when products are refreshed

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e56e464f788325b8f512f18435dd2a