### PR TITLE
Update jobs header with close navigation

### DIFF
--- a/jobs.html
+++ b/jobs.html
@@ -10,6 +10,10 @@
       href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;700;800&display=swap"
       rel="stylesheet"
     />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined"
+      rel="stylesheet"
+    />
     <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
     <script>
       tailwind.config = {
@@ -46,38 +50,43 @@
         <header
           class="sticky top-0 bg-background-light dark:bg-background-dark/80 backdrop-blur-sm z-10 px-4 pt-6 pb-4"
         >
-          <div class="flex items-center justify-between">
-            <div>
-              <h1 class="text-2xl font-bold text-black dark:text-white">
-                Jobs
-              </h1>
-              <p class="text-sm text-gray-600 dark:text-gray-400">
-                Monitor processing status for each job.
-              </p>
-            </div>
-            <button
-              class="flex items-center gap-2 rounded-full border border-black/10 dark:border-white/10 px-4 py-2 text-sm font-medium text-black dark:text-white hover:bg-primary/10 transition-colors"
-              id="refresh-jobs"
-              type="button"
-            >
-              <svg
-                class="size-4"
-                fill="none"
-                height="24"
-                stroke="currentColor"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
+          <div class="flex items-center justify-between gap-4">
+            <h1 class="text-2xl font-bold text-black dark:text-white">Jobs</h1>
+            <div class="flex items-center gap-3">
+              <button
+                class="flex items-center gap-2 rounded-full border border-black/10 dark:border-white/10 px-4 py-2 text-sm font-medium text-black dark:text-white hover:bg-primary/10 transition-colors"
+                id="refresh-jobs"
+                type="button"
               >
-                <path d="M21 2v6h-6" />
-                <path d="M3 12a9 9 0 0 1 15-6l3 3M3 22v-6h6" />
-                <path d="M21 12a9 9 0 0 1-15 6l-3-3" />
-              </svg>
-              Refresh
-            </button>
+                <svg
+                  class="size-4"
+                  fill="none"
+                  height="24"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  viewBox="0 0 24 24"
+                  width="24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path d="M21 2v6h-6" />
+                  <path d="M3 12a9 9 0 0 1 15-6l3 3M3 22v-6h6" />
+                  <path d="M21 12a9 9 0 0 1-15 6l-3-3" />
+                </svg>
+                Refresh
+              </button>
+              <button
+                aria-label="Close"
+                class="flex size-12 items-center justify-center rounded-full bg-black/5 text-black transition hover:bg-black/10 dark:bg-white/10 dark:text-white dark:hover:bg-white/20"
+                onclick="window.location.href='index.html';"
+                type="button"
+              >
+                <span class="material-symbols-outlined text-3xl leading-none">
+                  close
+                </span>
+              </button>
+            </div>
           </div>
         </header>
         <main class="px-4 pb-32">


### PR DESCRIPTION
## Summary
- remove the descriptive subtext beneath the Jobs header
- add a close button that returns to the index page to match the manage view
- load the material icon font needed for the new close icon

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6600390a883258bb0eef4a83f2bdf